### PR TITLE
Fix unavailable server configuration

### DIFF
--- a/mcp_server/Dockerfile
+++ b/mcp_server/Dockerfile
@@ -1,0 +1,19 @@
+# Use an official Python runtime as a parent image
+FROM python:3.10-slim
+
+# Set the working directory
+WORKDIR /app
+
+# Copy requirements and install dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the server code
+COPY . .
+
+# Expose the main and generated API ports
+EXPOSE 8000
+EXPOSE 8001
+
+# Start the server
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Add Dockerfile to enable automatic building and deployment of the MCP server.

This Dockerfile allows the server to be built and run via Docker (e.g., on smithery.ai), addressing the user's need for a deployable and connectable server, especially given its initial "configuration unavailable" status.

---

[Open in Web](https://www.cursor.com/agents?id=bc-216447b6-f754-41e3-93eb-920dd0563b4a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-216447b6-f754-41e3-93eb-920dd0563b4a)