### PR TITLE
Fix mcp server capability data type mismatch

### DIFF
--- a/mcp_server/mcp_bridge.py
+++ b/mcp_server/mcp_bridge.py
@@ -45,9 +45,9 @@ class MCPServer:
                 return self._create_response(request_id, {
                     "protocolVersion": "1.0",
                     "capabilities": {
-                        "tools": True,
-                        "resources": True,
-                        "prompts": True
+                        "tools": {},
+                        "resources": {},
+                        "prompts": {}
                     },
                     "serverInfo": {
                         "name": "python-to-api-mcp-server",


### PR DESCRIPTION
Update `mcp_bridge.py` to return empty objects for `capabilities.tools`, `resources`, and `prompts` to conform to the MCP spec.

---

[Open in Web](https://www.cursor.com/agents?id=bc-759f9230-1be9-4bfb-8575-6657b8166ba7) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-759f9230-1be9-4bfb-8575-6657b8166ba7)